### PR TITLE
Add support for AssumeRoleProvider Role credentials with optional MFA

### DIFF
--- a/config/aws/aws.go
+++ b/config/aws/aws.go
@@ -22,10 +22,11 @@ const (
 type (
 	// Config holds common AWS credentials and keys.
 	Config struct {
-		SecretKey string `envconfig:"AWS_SECRET_KEY"`
 		AccessKey string `envconfig:"AWS_ACCESS_KEY"`
-
+		MFASerialNumber string `envconfig:"AWS_MFA_SERIAL_NUMBER"`
 		Region string `envconfig:"AWS_REGION"`
+		RoleARN string `envconfig:"AWS_ROLE_ARN"`
+		SecretKey string `envconfig:"AWS_SECRET_KEY"`
 	}
 
 	// S3 holds the info required to work with Amazon S3.

--- a/pubsub/aws/config.go
+++ b/pubsub/aws/config.go
@@ -11,8 +11,8 @@ type (
 	// SQSConfig holds the info required to work with Amazon SQS
 	SQSConfig struct {
 		aws.Config
-
-		QueueName string `envconfig:"AWS_SQS_NAME"`
+		QueueName           string `envconfig:"AWS_SQS_NAME"`
+		QueueOwnerAccountID string `envconfig:"AWS_SQS_OWNER_ACCOUNT_ID"`
 		// MaxMessages will override the DefaultSQSMaxMessages.
 		MaxMessages *int64 `envconfig:"AWS_SQS_MAX_MESSAGES"`
 		// TimeoutSeconds will override the DefaultSQSTimeoutSeconds.


### PR DESCRIPTION
Adds few extra config values `RoleARN`, `MFASerialNumber` and `QueueOwnerAWSAccountId`

If `RoleARN` is set, the credentials are replaced with the one provided by AssumeRole
https://docs.aws.amazon.com/sdk-for-go/api/service/sts/#hdr-Using_MFA_with_AssumeRole

if `MFASerialNumber` is set, then the user will be prompted to insert the MFA code (using the `stscreds.StdinTokenProvider`)

Closes #1 